### PR TITLE
Bump to 1.1.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "qbit-export",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qbit-export",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@ckcr4lyf/logger": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbit-export",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Export .torrent files WITH tracker!",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
New release to npm (https://www.npmjs.com/package/qbit-export)

Adds `-n` flag to export with the torrent name as filename instead of hash (#2)